### PR TITLE
TT cutoffs

### DIFF
--- a/src/search/bench.rs
+++ b/src/search/bench.rs
@@ -19,7 +19,7 @@ pub fn run_bench() {
         let zobrist_stack = ZobristStack::new(&board);
 
         search_manager.update_state(&board, &zobrist_stack);
-        nodes += search_manager.start_bench_search(8);
+        nodes += search_manager.start_bench_search(10);
     }
 
     let nps = (u128::from(nodes) * 1_000_000) / stopwatch.elapsed().as_micros();

--- a/src/search/search_manager.rs
+++ b/src/search/search_manager.rs
@@ -335,7 +335,13 @@ impl Searcher {
         // PROBE TT
         let hash = self.zobrist_stack.current_hash();
         let tt_move = if let Some(tt_entry) = tt.probe(hash) {
-            tt_entry.mv // TODO: add tt cutoffs
+            let tt_score = tt_entry.score_from_tt(ply);
+            
+            if !is_pv && tt_entry.cutoff_is_possible(alpha, beta, depth) {
+                return tt_score;
+            }
+
+            tt_entry.mv
         } else {
             Move::NULL
         };


### PR DESCRIPTION
```
Elo   | 127.19 +- 24.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 542 W: 277 L: 87 D: 178
Penta | [7, 25, 73, 103, 63]
https://chess.swehosting.se/test/7114/
```