### PR TITLE
Qsearch TT cutoffs

### DIFF
--- a/plans.txt
+++ b/plans.txt
@@ -3,12 +3,12 @@ Merged:
 - SEE qsearch pruning: https://github.com/spamdrew128/Galumph/pull/32
 - TT replacement scheme: https://github.com/spamdrew128/Galumph/pull/33
 - Check extensions: https://github.com/spamdrew128/Galumph/pull/34
+- TT cutoffs in qsearch: https://github.com/spamdrew128/Galumph/pull/35
 
 Basic Plans:
 - Give bonus to promotions on top of MVV
 - Internal Iterative Reduction
 - Use static eval in search
-- TT cutoffs in qsearch
 - TT eval in qsearch
 - TT move ordering in qsearch
 - Add Static Eval to TT
@@ -25,4 +25,4 @@ Basic Plans:
 Experimental Ideas:
 - Shift killer table up by 2 ply when starting a new search
 - Use a net with two different kinds of activation functions in the hidden layer
-- Store hashfull
+- Store hashfull rather than recalculating every search

--- a/plans.txt
+++ b/plans.txt
@@ -8,7 +8,9 @@ Basic Plans:
 - Give bonus to promotions on top of MVV
 - Internal Iterative Reduction
 - Use static eval in search
-- TT in qsearch
+- TT cutoffs in qsearch
+- TT eval in qsearch
+- TT move ordering in qsearch
 - Add Static Eval to TT
 - Asp windows
 - Soft TM


### PR DESCRIPTION
```
Elo   | 8.11 +- 5.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7284 W: 2120 L: 1950 D: 3214
Penta | [145, 833, 1568, 899, 197]
https://chess.swehosting.se/test/7136/
```